### PR TITLE
Fix keyword search escaping

### DIFF
--- a/archibot_gpt_deploy/archibot_bot.py
+++ b/archibot_gpt_deploy/archibot_bot.py
@@ -134,7 +134,17 @@ class Archibot:
         return sections
 
     def search_keywords(self, text: str, keywords: List[str]) -> List[str]:
-        return [kw for kw in keywords if re.search(kw, text, re.IGNORECASE)]
+        """Return keywords found in ``text``.
+
+        Each keyword is treated as a literal string. Prior implementation used
+        ``re.search`` directly with the keyword, which interprets characters
+        such as ``.`` or ``/`` as regular expression meta characters. This
+        caused false positives or failed matches for specifications like
+        ``"CAN/CGSB 93.3"``. To avoid this we escape each keyword before
+        searching.
+        """
+
+        return [kw for kw in keywords if re.search(re.escape(kw), text, re.IGNORECASE)]
 
 def analyze_devis(text: str) -> Dict:
     bot = Archibot()

--- a/tests/test_search_keywords.py
+++ b/tests/test_search_keywords.py
@@ -1,0 +1,18 @@
+import sys
+import types
+import os
+
+# Add project root to sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide a stub for the optional PyMuPDF dependency to allow import
+sys.modules.setdefault('fitz', types.ModuleType('fitz'))
+
+import archibot_gpt_deploy.archibot_bot as bot_module
+
+
+def test_search_keywords_special_chars():
+    bot = bot_module.Archibot()
+    text = "La norme CAN/CGSB 93.3 s'applique."
+    result = bot.search_keywords(text, ["CAN/CGSB 93.3"])
+    assert result == ["CAN/CGSB 93.3"]


### PR DESCRIPTION
## Summary
- escape regex metacharacters when searching for keywords
- package the source directory so it can be imported in tests
- add tests covering search of strings with special characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad64872788322930399363aabdb5f