### PR TITLE
Add PyTest suite and search function improvements

### DIFF
--- a/archibot_gpt_deploy/archibot_bot.py
+++ b/archibot_gpt_deploy/archibot_bot.py
@@ -134,7 +134,17 @@ class Archibot:
         return sections
 
     def search_keywords(self, text: str, keywords: List[str]) -> List[str]:
-        return [kw for kw in keywords if re.search(kw, text, re.IGNORECASE)]
+        """Return keywords found in the provided text.
+
+        Regex special characters within keywords are escaped so that each
+        keyword is searched for literally, and the search is performed in a
+        case-insensitive manner.
+        """
+        return [
+            kw
+            for kw in keywords
+            if re.search(re.escape(kw), text, re.IGNORECASE)
+        ]
 
 def analyze_devis(text: str) -> Dict:
     bot = Archibot()

--- a/archibot_gpt_deploy/requirements.txt
+++ b/archibot_gpt_deploy/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 PyMuPDF
+pytest

--- a/tests/test_archibot.py
+++ b/tests/test_archibot.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import types
+import pytest
+
+# Ensure the module can be imported when tests are run from the repo root
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "archibot_gpt_deploy"))
+
+# Provide a minimal stub for the optional PyMuPDF dependency if it's missing
+if 'fitz' not in sys.modules:
+    sys.modules['fitz'] = types.ModuleType('fitz')
+
+from archibot_bot import Archibot
+
+
+def test_split_sections():
+    text = (
+        "Conditions générales\nDetails CG.\n"
+        "Revêtements extérieurs\nDetails RE.\n"
+        "Béton\nDetails B."
+    )
+    bot = Archibot()
+    sections = bot.split_sections(text)
+    assert sections["Conditions générales"] == "Details CG."
+    assert sections["Revêtements extérieurs"] == "Details RE."
+    assert sections["Béton"] == "Details B."
+
+
+def test_search_keywords_with_punctuation_and_case_insensitive():
+    text = "The spec uses A{2} and b#1 with extras. aama 508 is referenced."
+    keywords = ["A{2}", "B#1", "AAMA 508"]
+    bot = Archibot()
+    found = bot.search_keywords(text, keywords)
+    assert set(found) == {"A{2}", "B#1", "AAMA 508"}
+


### PR DESCRIPTION
## Summary
- add unit tests for `split_sections` and `search_keywords`
- improve `search_keywords` escaping
- include `pytest` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad7196cf483229a114f72bc82479e